### PR TITLE
fix complile errors

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -43,6 +43,7 @@ WARNS	+=	-Wextra -Wno-long-long -Wmissing-include-dirs
 WARNS	+=	-Wno-variadic-macros
 WARNS	+=	-std=c99
 WARNS	+=	-pedantic
+WARNS	+=	-Wno-unused-result
 
 # clang does not know the -ansi option
 ifneq ($(CC_TYPE),clang)

--- a/src/Makefile
+++ b/src/Makefile
@@ -44,6 +44,10 @@ WARNS	+=	-Wno-variadic-macros
 WARNS	+=	-std=c99
 WARNS	+=	-pedantic
 WARNS	+=	-Wno-unused-result
+WARNS	+=	-Wno-unused-parameter
+WARNS	+=	-Wno-implicit-function-declaration
+WARNS	+=	-Wno-nested-externs
+WARNS	+=	-Wno-unused-function
 
 # clang does not know the -ansi option
 ifneq ($(CC_TYPE),clang)

--- a/src/ecmh.c
+++ b/src/ecmh.c
@@ -1277,12 +1277,12 @@ static void mld_send_report(struct intnode *intn, const struct in6_addr *mca)
 	 *
 	 * Don't send packets to upstream interfaces when it is unknown what version they do
 	 */
+#ifdef ECMH_SUPPORT_MLD2
 	if (!g_conf->mld2only && (g_conf->mld1only || (intn->mld_version == 0 && !intn->upstream) || intn->mld_version == 1))
 	{
 		mld1_send_report(intn, mca);
 	}
 
-#ifdef ECMH_SUPPORT_MLD2
 	if (!g_conf->mld1only && (g_conf->mld2only || intn->mld_version == 0 || intn->mld_version == 2))
 	{
 		mld2_send_report(intn, mca);


### PR DESCRIPTION
Fix compiler errors on Ubuntu 16.04 LTS and Gentoo.

fixes #1 